### PR TITLE
bugfix: verify booking ownership validation

### DIFF
--- a/src/main/java/com/dineflex/controller/BookingController.java
+++ b/src/main/java/com/dineflex/controller/BookingController.java
@@ -7,6 +7,7 @@ import com.dineflex.service.BookingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.Authentication;
 import com.dineflex.entity.Booking;
 
 @RestController
@@ -24,7 +25,8 @@ public class BookingController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<BookingResponse> getBooking(@PathVariable Long id) {
-        return ResponseEntity.ok(bookingService.getBookingById(id));
+    public ResponseEntity<BookingResponse> getBooking(@PathVariable Long id, Authentication authentication) {
+        String customerEmail = authentication.getName();
+        return ResponseEntity.ok(bookingService.getBookingById(id, customerEmail));
     }
 }

--- a/src/main/java/com/dineflex/service/BookingService.java
+++ b/src/main/java/com/dineflex/service/BookingService.java
@@ -6,5 +6,5 @@ import com.dineflex.entity.Booking;
 
 public interface BookingService {
     Booking createBooking(BookingRequest request);
-    BookingResponse getBookingById(Long id);
+    BookingResponse getBookingById(Long id, String customerEmail);
 }

--- a/src/main/java/com/dineflex/service/impl/BookingServiceImpl.java
+++ b/src/main/java/com/dineflex/service/impl/BookingServiceImpl.java
@@ -4,12 +4,12 @@ import com.dineflex.dto.request.BookingRequest;
 import com.dineflex.dto.response.BookingResponse;
 import com.dineflex.entity.*;
 import com.dineflex.entity.enums.BookingStatus;
-import com.dineflex.entity.enums.BookingStatus;
 import com.dineflex.exception.UserNotFoundException;
 import com.dineflex.repository.*;
 import com.dineflex.service.BookingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.security.access.AccessDeniedException;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -69,9 +69,14 @@ public class BookingServiceImpl implements BookingService {
 
 
     @Override
-    public BookingResponse getBookingById(Long bookingId) {
+    public BookingResponse getBookingById(Long bookingId, String customerEmail) {
         Booking booking = bookingRepository.findById(bookingId)
                 .orElseThrow(() -> new IllegalArgumentException("Booking not found"));
+
+        if (!booking.getCustomer().getCustomerEmail().equals(customerEmail)) {
+            throw new AccessDeniedException("This booking does not belong to the customer");
+        }
+
         return BookingResponse.fromEntity(booking);
     }
 

--- a/src/test/java/com/dineflex/controller/BookingControllerTest.java
+++ b/src/test/java/com/dineflex/controller/BookingControllerTest.java
@@ -26,6 +26,8 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -140,7 +142,7 @@ class BookingControllerTest {
 
     @Test
     void getBookingById_shouldReturn200_whenFound() throws Exception {
-        when(bookingService.getBookingById(1L)).thenReturn(bookingResponse);
+        when(bookingService.getBookingById(eq(1L), anyString())).thenReturn(bookingResponse);
 
         mockMvc.perform(get("/api/bookings/1"))
                 .andExpect(status().isOk())
@@ -151,7 +153,7 @@ class BookingControllerTest {
 
     @Test
     void getBookingById_shouldReturn500_whenNotFound() throws Exception {
-        when(bookingService.getBookingById(99L))
+        when(bookingService.getBookingById(eq(99L), anyString()))
                 .thenThrow(new IllegalArgumentException("Booking not found"));
 
         mockMvc.perform(get("/api/bookings/99"))

--- a/src/test/java/com/dineflex/service/impl/BookingServiceImplTest.java
+++ b/src/test/java/com/dineflex/service/impl/BookingServiceImplTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -183,7 +184,7 @@ class BookingServiceImplTest {
     void getBookingById_shouldReturnBookingResponse_whenBookingExists() {
         when(bookingRepository.findById(1L)).thenReturn(Optional.of(savedBooking));
 
-        BookingResponse response = bookingService.getBookingById(1L);
+        BookingResponse response = bookingService.getBookingById(1L, "test@example.com");
 
         assertThat(response).isNotNull();
         assertThat(response.getId()).isEqualTo(1L);
@@ -196,8 +197,17 @@ class BookingServiceImplTest {
     void getBookingById_shouldThrowException_whenBookingNotFound() {
         when(bookingRepository.findById(99L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> bookingService.getBookingById(99L))
+        assertThatThrownBy(() -> bookingService.getBookingById(99L, "test@example.com"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Booking not found");
+    }
+
+    @Test
+    void getBookingById_shouldThrowException_whenCustomerDoesNotOwnBooking() {
+        when(bookingRepository.findById(1L)).thenReturn(Optional.of(savedBooking));
+
+        assertThatThrownBy(() -> bookingService.getBookingById(1L, "other@example.com"))
+            .isInstanceOf(AccessDeniedException.class)
+            .hasMessage("This booking does not belong to the customer");
     }
 }


### PR DESCRIPTION
## What this PR does
Fixes an IDOR vulnerability in the booking access logic by ensuring that only the owner of a booking can access or modify it.

## The problem
Previously, users could access or manipulate bookings that did not belong to them by guessing or modifying booking IDs.

## The fix
- Added validation to check booking ownership against the authenticated user
- Restricted access if the booking does not belong to the user
- Ensured all relevant endpoints enforce this check

## Comments
- I know you recommended @AuthenticationPrincipal but some things needed to be changed around for that and I did not want to mess up any structure. Let me know in the comments if my changes are fine or you would like to discuss more of how you wanted that annotation implemented.